### PR TITLE
Using comma-separated list of globs to set files to include and exclude

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
-.settings
-target
-.classpath
-.project
+/.settings
+/bin
+/build
+/dist
+/target
+/.classpath
+/.project
 .DS_Store
-bin

--- a/README.md
+++ b/README.md
@@ -1,57 +1,61 @@
 Encode Enforcer
+===============
 
 Maven Enforcer Plugin custom rule for enforcing file encodings.
 
-To Install :
+To Install
+----------
 
-1.  git clone https://github.com/mikedon/encoding-enforcer.git
+1. `git clone https://github.com/mikedon/encoding-enforcer.git`
 
-2.  cd encoding-enforcer
+1. `cd encoding-enforcer`
 
-3.  mvn clean install
+1. `mvn clean install`
 
-Example Usage:
-
+Example Usage
+-------------
 ```
 <properties>
-	<!-- The rule uses this property to validate file encodings against -->
-	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  <!-- The rule uses this property to validate file encodings against -->
+  <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 </properties>
 
 <build>
-	<plugins>
-		<plugin>
-	        <groupId>org.apache.maven.plugins</groupId>
-			<artifactId>maven-enforcer-plugin</artifactId>
-			<version>1.2</version>
-			<dependencies>
-				<dependency>
-					<groupId>com.miked</groupId>
-					<artifactId>encoding-enforcer</artifactId>
-					<version>1.0</version>
-				</dependency>
-			</dependencies>
-			<executions>
-			<execution>
-				<id>enforce-encoding</id>
-				<goals>
-					<goal>enforce</goal>
-				</goals>
-				<configuration>
-					<rules>
-			            <encodingRule implementation="com.miked.maven.enforcer.rule.EncodingRule">
-							<!-- Directory to check for files -->
-			            	<directory>relative/path</directory>
-							<!-- Regular expression to match file names against -->
-			            	<includes>.*\.properties</includes>
-			            	<!-- Validate files match this encoding. -->
-			            	<encoding>UTF-8</encoding>
-			            </encodingRule>
-          			</rules>
-				</configuration>
-			</execution>
-        </executions>
-	    </plugin>   
-	</plugins>
+  <plugins>
+    <plugin>
+      <groupId>org.apache.maven.plugins</groupId>
+      <artifactId>maven-enforcer-plugin</artifactId>
+      <version>1.2</version>
+      <dependencies>
+        <dependency>
+          <groupId>com.miked</groupId>
+          <artifactId>encoding-enforcer</artifactId>
+          <version>2.0</version>
+        </dependency>
+      </dependencies>
+      <executions>
+        <execution>
+          <id>enforce-encoding</id>
+          <goals>
+            <goal>enforce</goal>
+          </goals>
+          <configuration>
+            <rules>
+              <requireEncoding implementation="com.miked.maven.enforcer.rule.RequireEncoding">
+                <!-- Validate files against this encoding -->
+                <encoding>UTF-8</encoding>
+                <!-- Comma-separated globs of files to be validated -->
+                <includes>src/**/*.java,**/*.xml</includes>
+                <!-- Comma-separated globs of files to be excluded from validation -->
+                <excludes>target/**</excludes>
+                <!-- Enables SCM files exclusions -->
+                <useDefaultExcludes>true</useDefaultExcludes>
+              </requireEncoding>
+            </rules>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
 </build>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>com.miked</groupId>
 	<artifactId>encoding-enforcer</artifactId>
 	<packaging>jar</packaging>
-	<version>1.0</version>
-	<name>File Encoding Enforcer</name>
+	<version>2.0</version>
+	
+	<name>File Encoding Enforcer Rule</name>
 	<description>This rule forces all files to be encoded using the specified encoding.</description>
+	
 	<properties>
-	  	<api.version>1.2</api.version>
-	  	<maven.version>2.2.1</maven.version>
+		<api.version>1.2</api.version>
+		<maven.version>2.2.1</maven.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
+	
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.maven.enforcer</groupId>
@@ -52,16 +57,11 @@
 			<version>${maven.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.codehaus.plexus</groupId>
-			<artifactId>plexus-container-default</artifactId>
-			<version>1.0-alpha-9</version>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.5</version>
+			<version>4.11</version>
 			<scope>test</scope>
-		</dependency>	
+		</dependency>
 		<dependency>
 			<groupId>com.googlecode.juniversalchardet</groupId>
 			<artifactId>juniversalchardet</artifactId>
@@ -81,5 +81,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/test/java/com/miked/maven/enforcer/rule/RequireEncodingTest.java
+++ b/src/test/java/com/miked/maven/enforcer/rule/RequireEncodingTest.java
@@ -6,7 +6,7 @@ import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
 import org.apache.maven.plugins.enforcer.EnforcerTestUtils;
 import org.junit.Test;
 
-public class EncodingRuleTest {
+public class RequireEncodingTest {
 
 	@Test
 	public void testValidFile() {
@@ -25,10 +25,9 @@ public class EncodingRuleTest {
 
 	protected void testFile(boolean expected, String encoding, String file) {
 		boolean isValid;
-		EncodingRule rule = new EncodingRule();
+		RequireEncoding rule = new RequireEncoding();
 		rule.setEncoding(encoding);
-		rule.setDirectory("/src/test/resources/");
-		rule.setIncludes(file);
+		rule.setIncludes("src/test/resources/" + file);
 		try {
 			rule.execute(EnforcerTestUtils.getHelper());
 			isValid = true;


### PR DESCRIPTION
A set of files to be validated can be defined using lists of globs with patters to match against files to be included or excluded from validation, like

```
<!-- Comma-separated globs of files to be validated -->
<includes>src/**/*.java, **/*.xml</includes>
<!-- Comma-separated globs of files to be excluded from validation -->
<excludes>target/**</excludes>
```
